### PR TITLE
Improve data receiving before pushing to LwIP.  

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -4,7 +4,7 @@ cwd = GetCurrentDir()
 path = [cwd + '/inc']
 src  = Glob('src/*.c')
 if GetDepend(['PPP_DEVICE_SAMPLE']):
-	src += Glob('samples/ppp_sample.c')
+    src += Glob('samples/ppp_sample.c')
 
 # Air720
 if GetDepend(['PPP_DEVICE_USING_AIR720']):

--- a/SConscript
+++ b/SConscript
@@ -3,7 +3,8 @@ from building import *
 cwd = GetCurrentDir()
 path = [cwd + '/inc']
 src  = Glob('src/*.c')
-src += Glob('samples/ppp_sample.c')
+if GetDepend(['PPP_DEVICE_SAMPLE']):
+	src += Glob('samples/ppp_sample.c')
 
 # Air720
 if GetDepend(['PPP_DEVICE_USING_AIR720']):


### PR DESCRIPTION
LWIP PPP has problems when pushing data in small segments. 
This problem is less likely in UART DMA mode. But very likely in INT mode, where data are pushed in a single byte. 
We should push data in a larger batch. 

- In receiving, wait for data until buffer full or until data stop for 1ms. 
- Enlarge data buffer size from 32 to 128. Also, increase thread stack size to 1280 to avoid stack overflow. 

Tested with STM32H7A3 + SIM800C, uart baudrate from 9600 to 115200.

~~~
ppp phase changed[0]: phase=10
pppos_netif_output[0]: proto=0x21, len = 64
pppos_netif_output[0]: proto=0x21, len = 64
pppos_input[0]: got 29 bytes      <<<--- see it is now combining incoming data 
pppos_input[0]: got 128 bytes    <<<--- see it is now combining incoming data 
ppp_input[0]: ip in pbuf len=80
pppos_input[0]: got 15 bytes
ppp_input[0]: ip in pbuf len=80
pppos_netif_output[0]: proto=0x21, len = 56
pppos_netif_output[0]: proto=0x21, len = 40
pppos_input[0]: got 35 bytes
ppp_input[0]: ip in pbuf len=29
~~~